### PR TITLE
解决最大滑动区域为负数，滑动结束后错位的bug

### DIFF
--- a/components/popup-scroll/popup-scroll.vue
+++ b/components/popup-scroll/popup-scroll.vue
@@ -16,7 +16,7 @@
 		},
 		computed: {
 			maxScrollY() {
-				return this.scrollHeight - this.boxHeight
+				return Math.max(this.scrollHeight - this.boxHeight, 0)
 			},
 			isOut(){
 				let maxScrollY = this.maxScrollY


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11306583/104676399-47339700-5722-11eb-8ca2-4f1ad7ced8f8.png)
